### PR TITLE
Add models and migrations for OpenAI prompt manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # OpenaiPromptManager
-Short description and motivation.
+Manage reusable prompts and tool definitions for OpenAI integrations in a Rails
+application.
 
 ## Usage
-How to use my plugin.
+Run the engine migrations and create your prompts and tools using the provided
+ActiveRecord models.
+
+```ruby
+# Example
+tool = OpenaiPromptManager::Tool.create!(name: "Summarizer")
+prompt = tool.prompts.create!(name: "Summary", content: "Summarize: {text}")
+
+client = OpenaiPromptManager::Client.new
+client.call(prompt, variables: { text: "Hello" }, model: "gpt-3.5-turbo")
+```
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/app/models/openai_prompt_manager/prompt.rb
+++ b/app/models/openai_prompt_manager/prompt.rb
@@ -1,0 +1,15 @@
+module OpenaiPromptManager
+  class Prompt < ApplicationRecord
+    belongs_to :tool, class_name: 'OpenaiPromptManager::Tool', optional: true
+
+    validates :name, presence: true
+    validates :content, presence: true
+
+    # Replace {variable} placeholders in the content with provided variables
+    def render(variables = {})
+      variables.reduce(content.dup) do |result, (key, value)|
+        result.gsub("{#{key}}", value.to_s)
+      end
+    end
+  end
+end

--- a/app/models/openai_prompt_manager/tool.rb
+++ b/app/models/openai_prompt_manager/tool.rb
@@ -1,0 +1,7 @@
+module OpenaiPromptManager
+  class Tool < ApplicationRecord
+    has_many :prompts, class_name: 'OpenaiPromptManager::Prompt', dependent: :destroy
+
+    validates :name, presence: true
+  end
+end

--- a/db/migrate/20240101000000_create_openai_prompt_manager_tools.rb
+++ b/db/migrate/20240101000000_create_openai_prompt_manager_tools.rb
@@ -1,0 +1,10 @@
+class CreateOpenaiPromptManagerTools < ActiveRecord::Migration[8.0]
+  def change
+    create_table :openai_prompt_manager_tools do |t|
+      t.string :name, null: false
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240101000001_create_openai_prompt_manager_prompts.rb
+++ b/db/migrate/20240101000001_create_openai_prompt_manager_prompts.rb
@@ -1,0 +1,11 @@
+class CreateOpenaiPromptManagerPrompts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :openai_prompt_manager_prompts do |t|
+      t.references :tool, null: true, foreign_key: { to_table: :openai_prompt_manager_tools }
+      t.string :name, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/openai_prompt_manager.rb
+++ b/lib/openai_prompt_manager.rb
@@ -1,6 +1,8 @@
 require "openai_prompt_manager/version"
 require "openai_prompt_manager/engine"
+require "openai_prompt_manager/client"
 
 module OpenaiPromptManager
-  # Your code goes here...
+  # Entry point for the engine. Additional functionality is provided in
+  # the individual classes.
 end

--- a/lib/openai_prompt_manager/client.rb
+++ b/lib/openai_prompt_manager/client.rb
@@ -1,0 +1,18 @@
+begin
+  require 'openai'
+rescue LoadError
+  warn 'OpenAI gem not installed; OpenaiPromptManager::Client will not function.'
+end
+
+module OpenaiPromptManager
+  class Client
+    def initialize(openai_client: OpenAI::Client.new)
+      @client = openai_client
+    end
+
+    def call(prompt, variables: {}, **options)
+      messages = [{ role: 'user', content: prompt.render(variables) }]
+      @client.chat(parameters: { messages: messages }.merge(options))
+    end
+  end
+end

--- a/lib/openai_prompt_manager/engine.rb
+++ b/lib/openai_prompt_manager/engine.rb
@@ -1,5 +1,13 @@
 module OpenaiPromptManager
   class Engine < ::Rails::Engine
     isolate_namespace OpenaiPromptManager
+
+    initializer :append_migrations do |app|
+      unless app.root.to_s.start_with?(root.to_s)
+        config.paths["db/migrate"].expanded.each do |expanded_path|
+          app.config.paths["db/migrate"] << expanded_path
+        end
+      end
+    end
   end
 end

--- a/test/dummy/db/migrate/20240101000000_create_openai_prompt_manager_tools.rb
+++ b/test/dummy/db/migrate/20240101000000_create_openai_prompt_manager_tools.rb
@@ -1,0 +1,10 @@
+class CreateOpenaiPromptManagerTools < ActiveRecord::Migration[8.0]
+  def change
+    create_table :openai_prompt_manager_tools do |t|
+      t.string :name, null: false
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20240101000001_create_openai_prompt_manager_prompts.rb
+++ b/test/dummy/db/migrate/20240101000001_create_openai_prompt_manager_prompts.rb
@@ -1,0 +1,11 @@
+class CreateOpenaiPromptManagerPrompts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :openai_prompt_manager_prompts do |t|
+      t.references :tool, null: true, foreign_key: { to_table: :openai_prompt_manager_tools }
+      t.string :name, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/test/models/openai_prompt_manager/prompt_test.rb
+++ b/test/models/openai_prompt_manager/prompt_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+module OpenaiPromptManager
+  class PromptTest < ActiveSupport::TestCase
+    test "renders variables" do
+      tool = Tool.create!(name: "Test")
+      prompt = tool.prompts.create!(name: "Greet", content: "Hello, {name}!")
+
+      assert_equal "Hello, world!", prompt.render(name: "world")
+    end
+  end
+end

--- a/test/models/openai_prompt_manager/tool_test.rb
+++ b/test/models/openai_prompt_manager/tool_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+module OpenaiPromptManager
+  class ToolTest < ActiveSupport::TestCase
+    test "name presence validation" do
+      tool = Tool.new
+      assert tool.invalid?
+      assert_includes tool.errors[:name], "can't be blank"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Tool and Prompt models
- create engine migrations and expose them to host app
- add client wrapper for OpenAI requests
- document basic usage
- add minimal model tests

## Testing
- `bin/rubocop` *(fails: Bundler::GemNotFound)*
- `ruby bin/rails test` *(fails: Bundler::GemNotFound)*