### PR TITLE
Add models and migrations for OpenAI prompt manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # OpenaiPromptManager
-Short description and motivation.
+Manage reusable prompts and tool definitions for OpenAI integrations in a Rails
+application.
 
 ## Usage
-How to use my plugin.
+Run the engine migrations and create your prompts and tools using the provided
+ActiveRecord models. Mount the engine to access a simple CRUD interface for
+managing tools and prompts:
+
+```ruby
+Rails.application.routes.draw do
+  mount OpenaiPromptManager::Engine => "/openai_prompt_manager"
+end
+```
+
+```ruby
+# Example
+tool = OpenaiPromptManager::Tool.create!(name: "Summarizer")
+prompt = tool.prompts.create!(name: "Summary", content: "Summarize: {text}")
+
+client = OpenaiPromptManager::Client.new
+client.call(prompt, variables: { text: "Hello" }, model: "gpt-3.5-turbo")
+```
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/app/controllers/openai_prompt_manager/prompts_controller.rb
+++ b/app/controllers/openai_prompt_manager/prompts_controller.rb
@@ -1,0 +1,54 @@
+module OpenaiPromptManager
+  class PromptsController < ApplicationController
+    before_action :set_tool
+    before_action :set_prompt, only: %i[show edit update destroy]
+
+    def index
+      @prompts = @tool.prompts
+    end
+
+    def show; end
+
+    def new
+      @prompt = @tool.prompts.build
+    end
+
+    def edit; end
+
+    def create
+      @prompt = @tool.prompts.build(prompt_params)
+      if @prompt.save
+        redirect_to [@tool, @prompt], notice: 'Prompt was successfully created.'
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      if @prompt.update(prompt_params)
+        redirect_to [@tool, @prompt], notice: 'Prompt was successfully updated.'
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @prompt.destroy
+      redirect_to tool_prompts_url(@tool), notice: 'Prompt was successfully destroyed.'
+    end
+
+    private
+
+    def set_tool
+      @tool = Tool.find(params[:tool_id])
+    end
+
+    def set_prompt
+      @prompt = @tool.prompts.find(params[:id])
+    end
+
+    def prompt_params
+      params.require(:prompt).permit(:name, :content)
+    end
+  end
+end

--- a/app/controllers/openai_prompt_manager/tools_controller.rb
+++ b/app/controllers/openai_prompt_manager/tools_controller.rb
@@ -1,0 +1,49 @@
+module OpenaiPromptManager
+  class ToolsController < ApplicationController
+    before_action :set_tool, only: %i[show edit update destroy]
+
+    def index
+      @tools = Tool.all
+    end
+
+    def show; end
+
+    def new
+      @tool = Tool.new
+    end
+
+    def edit; end
+
+    def create
+      @tool = Tool.new(tool_params)
+      if @tool.save
+        redirect_to @tool, notice: 'Tool was successfully created.'
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      if @tool.update(tool_params)
+        redirect_to @tool, notice: 'Tool was successfully updated.'
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @tool.destroy
+      redirect_to tools_url, notice: 'Tool was successfully destroyed.'
+    end
+
+    private
+
+    def set_tool
+      @tool = Tool.find(params[:id])
+    end
+
+    def tool_params
+      params.require(:tool).permit(:name, :description)
+    end
+  end
+end

--- a/app/models/openai_prompt_manager/prompt.rb
+++ b/app/models/openai_prompt_manager/prompt.rb
@@ -1,0 +1,15 @@
+module OpenaiPromptManager
+  class Prompt < ApplicationRecord
+    belongs_to :tool, class_name: 'OpenaiPromptManager::Tool', optional: true
+
+    validates :name, presence: true
+    validates :content, presence: true
+
+    # Replace {variable} placeholders in the content with provided variables
+    def render(variables = {})
+      variables.reduce(content.dup) do |result, (key, value)|
+        result.gsub("{#{key}}", value.to_s)
+      end
+    end
+  end
+end

--- a/app/models/openai_prompt_manager/tool.rb
+++ b/app/models/openai_prompt_manager/tool.rb
@@ -1,0 +1,7 @@
+module OpenaiPromptManager
+  class Tool < ApplicationRecord
+    has_many :prompts, class_name: 'OpenaiPromptManager::Prompt', dependent: :destroy
+
+    validates :name, presence: true
+  end
+end

--- a/app/views/openai_prompt_manager/prompts/_form.html.erb
+++ b/app/views/openai_prompt_manager/prompts/_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_with(model: [@tool, prompt], local: true) do |form| %>
+  <% if prompt.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(prompt.errors.count, 'error') %> prohibited this prompt from being saved:</h2>
+      <ul>
+      <% prompt.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.label :content %>
+    <%= form.text_area :content %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/openai_prompt_manager/prompts/edit.html.erb
+++ b/app/views/openai_prompt_manager/prompts/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>Edit Prompt for <%= @tool.name %></h1>
+
+<%= render 'form', tool: @tool, prompt: @prompt %>
+
+<%= link_to 'Back', tool_prompts_path(@tool) %>

--- a/app/views/openai_prompt_manager/prompts/index.html.erb
+++ b/app/views/openai_prompt_manager/prompts/index.html.erb
@@ -1,0 +1,25 @@
+<h1>Prompts for <%= @tool.name %></h1>
+
+<%= link_to 'New Prompt', new_tool_prompt_path(@tool) %> |
+<%= link_to 'Back to Tools', tools_path %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Content</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @prompts.each do |prompt| %>
+      <tr>
+        <td><%= prompt.name %></td>
+        <td><%= truncate(prompt.content, length: 60) %></td>
+        <td><%= link_to 'Show', [@tool, prompt] %></td>
+        <td><%= link_to 'Edit', edit_tool_prompt_path(@tool, prompt) %></td>
+        <td><%= link_to 'Destroy', [@tool, prompt], method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/openai_prompt_manager/prompts/new.html.erb
+++ b/app/views/openai_prompt_manager/prompts/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Prompt for <%= @tool.name %></h1>
+
+<%= render 'form', tool: @tool, prompt: @prompt %>
+
+<%= link_to 'Back', tool_prompts_path(@tool) %>

--- a/app/views/openai_prompt_manager/prompts/show.html.erb
+++ b/app/views/openai_prompt_manager/prompts/show.html.erb
@@ -1,0 +1,14 @@
+<h2>Prompt Details</h2>
+
+<p>
+  <strong>Name:</strong>
+  <%= @prompt.name %>
+</p>
+
+<p>
+  <strong>Content:</strong>
+  <%= simple_format(@prompt.content) %>
+</p>
+
+<%= link_to 'Edit', edit_tool_prompt_path(@tool, @prompt) %> |
+<%= link_to 'Back', tool_prompts_path(@tool) %>

--- a/app/views/openai_prompt_manager/tools/_form.html.erb
+++ b/app/views/openai_prompt_manager/tools/_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_with(model: tool, local: true) do |form| %>
+  <% if tool.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(tool.errors.count, "error") %> prohibited this tool from being saved:</h2>
+      <ul>
+      <% tool.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.label :description %>
+    <%= form.text_area :description %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/openai_prompt_manager/tools/edit.html.erb
+++ b/app/views/openai_prompt_manager/tools/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>Edit Tool</h1>
+
+<%= render 'form', tool: @tool %>
+
+<%= link_to 'Back', tools_path %>

--- a/app/views/openai_prompt_manager/tools/index.html.erb
+++ b/app/views/openai_prompt_manager/tools/index.html.erb
@@ -1,0 +1,25 @@
+<h1>Tools</h1>
+
+<%= link_to 'New Tool', new_tool_path %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @tools.each do |tool| %>
+      <tr>
+        <td><%= tool.name %></td>
+        <td><%= tool.description %></td>
+        <td><%= link_to 'Show', tool %></td>
+        <td><%= link_to 'Edit', edit_tool_path(tool) %></td>
+        <td><%= link_to 'Destroy', tool, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/openai_prompt_manager/tools/new.html.erb
+++ b/app/views/openai_prompt_manager/tools/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Tool</h1>
+
+<%= render 'form', tool: @tool %>
+
+<%= link_to 'Back', tools_path %>

--- a/app/views/openai_prompt_manager/tools/show.html.erb
+++ b/app/views/openai_prompt_manager/tools/show.html.erb
@@ -1,0 +1,12 @@
+<p>
+  <strong>Name:</strong>
+  <%= @tool.name %>
+</p>
+
+<p>
+  <strong>Description:</strong>
+  <%= @tool.description %>
+</p>
+
+<%= link_to 'Edit', edit_tool_path(@tool) %> |
+<%= link_to 'Back', tools_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,7 @@
 OpenaiPromptManager::Engine.routes.draw do
+  resources :tools do
+    resources :prompts
+  end
+
+  root to: 'tools#index'
 end

--- a/db/migrate/20240101000000_create_openai_prompt_manager_tools.rb
+++ b/db/migrate/20240101000000_create_openai_prompt_manager_tools.rb
@@ -1,0 +1,10 @@
+class CreateOpenaiPromptManagerTools < ActiveRecord::Migration[8.0]
+  def change
+    create_table :openai_prompt_manager_tools do |t|
+      t.string :name, null: false
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240101000001_create_openai_prompt_manager_prompts.rb
+++ b/db/migrate/20240101000001_create_openai_prompt_manager_prompts.rb
@@ -1,0 +1,11 @@
+class CreateOpenaiPromptManagerPrompts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :openai_prompt_manager_prompts do |t|
+      t.references :tool, null: true, foreign_key: { to_table: :openai_prompt_manager_tools }
+      t.string :name, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/openai_prompt_manager.rb
+++ b/lib/openai_prompt_manager.rb
@@ -1,6 +1,8 @@
 require "openai_prompt_manager/version"
 require "openai_prompt_manager/engine"
+require "openai_prompt_manager/client"
 
 module OpenaiPromptManager
-  # Your code goes here...
+  # Entry point for the engine. Additional functionality is provided in
+  # the individual classes.
 end

--- a/lib/openai_prompt_manager/client.rb
+++ b/lib/openai_prompt_manager/client.rb
@@ -1,0 +1,18 @@
+begin
+  require 'openai'
+rescue LoadError
+  warn 'OpenAI gem not installed; OpenaiPromptManager::Client will not function.'
+end
+
+module OpenaiPromptManager
+  class Client
+    def initialize(openai_client: OpenAI::Client.new)
+      @client = openai_client
+    end
+
+    def call(prompt, variables: {}, **options)
+      messages = [{ role: 'user', content: prompt.render(variables) }]
+      @client.chat(parameters: { messages: messages }.merge(options))
+    end
+  end
+end

--- a/lib/openai_prompt_manager/engine.rb
+++ b/lib/openai_prompt_manager/engine.rb
@@ -1,5 +1,13 @@
 module OpenaiPromptManager
   class Engine < ::Rails::Engine
     isolate_namespace OpenaiPromptManager
+
+    initializer :append_migrations do |app|
+      unless app.root.to_s.start_with?(root.to_s)
+        config.paths["db/migrate"].expanded.each do |expanded_path|
+          app.config.paths["db/migrate"] << expanded_path
+        end
+      end
+    end
   end
 end

--- a/test/controllers/openai_prompt_manager/prompts_controller_test.rb
+++ b/test/controllers/openai_prompt_manager/prompts_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+module OpenaiPromptManager
+  class PromptsControllerTest < ActionDispatch::IntegrationTest
+    include Engine.routes.url_helpers
+
+    setup do
+      @tool = Tool.create!(name: 'Test Tool')
+      @prompt = @tool.prompts.create!(name: 'Hello', content: 'Hi {name}')
+    end
+
+    test 'gets index' do
+      get tool_prompts_url(@tool)
+      assert_response :success
+    end
+
+    test 'shows prompt' do
+      get tool_prompt_url(@tool, @prompt)
+      assert_response :success
+    end
+  end
+end

--- a/test/controllers/openai_prompt_manager/tools_controller_test.rb
+++ b/test/controllers/openai_prompt_manager/tools_controller_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+module OpenaiPromptManager
+  class ToolsControllerTest < ActionDispatch::IntegrationTest
+    include Engine.routes.url_helpers
+
+    test 'gets index' do
+      get tools_url
+      assert_response :success
+    end
+  end
+end

--- a/test/dummy/db/migrate/20240101000000_create_openai_prompt_manager_tools.rb
+++ b/test/dummy/db/migrate/20240101000000_create_openai_prompt_manager_tools.rb
@@ -1,0 +1,10 @@
+class CreateOpenaiPromptManagerTools < ActiveRecord::Migration[8.0]
+  def change
+    create_table :openai_prompt_manager_tools do |t|
+      t.string :name, null: false
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20240101000001_create_openai_prompt_manager_prompts.rb
+++ b/test/dummy/db/migrate/20240101000001_create_openai_prompt_manager_prompts.rb
@@ -1,0 +1,11 @@
+class CreateOpenaiPromptManagerPrompts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :openai_prompt_manager_prompts do |t|
+      t.references :tool, null: true, foreign_key: { to_table: :openai_prompt_manager_tools }
+      t.string :name, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/test/models/openai_prompt_manager/prompt_test.rb
+++ b/test/models/openai_prompt_manager/prompt_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+module OpenaiPromptManager
+  class PromptTest < ActiveSupport::TestCase
+    test "renders variables" do
+      tool = Tool.create!(name: "Test")
+      prompt = tool.prompts.create!(name: "Greet", content: "Hello, {name}!")
+
+      assert_equal "Hello, world!", prompt.render(name: "world")
+    end
+  end
+end

--- a/test/models/openai_prompt_manager/tool_test.rb
+++ b/test/models/openai_prompt_manager/tool_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+module OpenaiPromptManager
+  class ToolTest < ActiveSupport::TestCase
+    test "name presence validation" do
+      tool = Tool.new
+      assert tool.invalid?
+      assert_includes tool.errors[:name], "can't be blank"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Tool and Prompt models
- create engine migrations and expose them to host app
- add client wrapper for OpenAI requests
- document basic usage
- add minimal model tests
- implement CRUD controllers, routes, and views for tools and prompts

## Testing
- `bin/rubocop` *(fails: Bundler::GemNotFound)*
- `ruby bin/rails test` *(fails: Bundler::GemNotFound)*